### PR TITLE
SimpleXMLElement::addChild only needs '&' to be escaped

### DIFF
--- a/xero.php
+++ b/xero.php
@@ -1283,7 +1283,7 @@ class ArrayToXML
             } else {
 
                 // add single node.
-                $value = htmlentities( $value );
+                $value = str_replace( '&', '&amp;', $value );
                 $xml->addChild( $key, $value );
             }
         }


### PR DESCRIPTION
(it handles everything else)
